### PR TITLE
fix: Improve semantic search by removing zero gender counts

### DIFF
--- a/main_app/main_pipeline.py
+++ b/main_app/main_pipeline.py
@@ -364,12 +364,18 @@ class CSVExporter:
                     except Exception:
                         pass
 
-            # Gender counts
+            # Gender counts - only include non-zero counts
             clip_obj = record.get('clip', {})
             genders = clip_obj.get('people_gender', [])
             women = sum(1 for g in genders if isinstance(g, dict) and CSVExporter._is_woman(g))
             men = len(genders) - women
-            parts.append(f"{men} men {women} women")
+            gender_parts = []
+            if men > 0:
+                gender_parts.append(f"{men} men")
+            if women > 0:
+                gender_parts.append(f"{women} women")
+            if gender_parts:
+                parts.append(" ".join(gender_parts))
 
             # Location info
             io = clip_obj.get('indoor_outdoor', 'unknown')


### PR DESCRIPTION
@- Modify main_pipeline.py to exclude zero gender counts from descriptions
- Only include non-zero counts (e.g., "3 men" or "2 women" instead of "3 men 0 women")
- Clean existing CSV data to remove 42 instances of distracting zero counts
- Semantic search results are now cleaner and more focused
- Examples: "7 men 0 women" → "7 men", "0 men 2 women" → "2 women"

🤖 Generated with [Claude Code](https://claude.ai/code)