### PR TITLE
fix: Replace max_completion_tokens with max_tokens for Groq API compa…

### DIFF
--- a/main_app/modules/llm.py
+++ b/main_app/modules/llm.py
@@ -294,7 +294,7 @@ Now, please analyze the historical photograph provided and return your response 
                     model="meta-llama/llama-4-maverick-17b-128e-instruct",
                     messages=messages_obj,
                     temperature=0.2,
-                    max_completion_tokens=1024,
+                    max_tokens=1024,
                     top_p=1,
                     stream=False,
                     response_format={"type": "json_object"},


### PR DESCRIPTION
…tibility

The Groq API expects max_tokens parameter, not max_completion_tokens. This fixes the API call failure that was causing LLM processing to fail.

🤖 Generated with [Claude Code](https://claude.ai/code)